### PR TITLE
refactor: Integrate atoms and sprinkles in Input and Button components

### DIFF
--- a/apps/web/components/InputTest.tsx
+++ b/apps/web/components/InputTest.tsx
@@ -1,11 +1,12 @@
-import { Input } from '@jung/design-system';
+import { Button, Input } from '@jung/design-system';
 
 const InputTest = () => {
 	return (
 		<>
-			<Input placeholder='primary' variant='primary' />
+			<Input placeholder='primary' variant='primary' padding='10' color='red' />
 			<Input placeholder='outline' variant='outline' />
 			<Input placeholder='ghost' variant='ghost' />
+			<Button padding='20'>hihi</Button>
 		</>
 	);
 };

--- a/packages/design-system/components/Box.tsx
+++ b/packages/design-system/components/Box.tsx
@@ -1,20 +1,21 @@
-import { type HTMLAttributes, forwardRef } from 'react';
+import { type ElementType, type HTMLAttributes, forwardRef } from 'react';
 import { type Atoms, atoms, extractAtoms } from '../utils/atoms';
 
 type HTMLProperties = Omit<
-	React.AllHTMLAttributes<HTMLElement>,
+	HTMLAttributes<HTMLElement>,
 	'as' | 'className' | 'color' | 'height' | 'width' | 'size'
 >;
 
 export type BoxProps = HTMLAttributes<HTMLElement> &
 	HTMLProperties &
 	Atoms & {
-		as?: React.ElementType;
+		as?: ElementType;
 	};
 
 export const Box = forwardRef<HTMLElement, BoxProps>((props, ref) => {
-	const { as: Component = 'div', ...other } = props;
-	const [atomsProps, propsToForward] = extractAtoms(other);
+	const { as, ...restProps } = props;
+	const [atomsProps, propsToForward] = extractAtoms(restProps);
+	const Component: ElementType = as || 'div';
 	const className = atoms({
 		className: propsToForward?.className,
 		reset: typeof Component === 'string' ? Component : 'div',

--- a/packages/design-system/components/Button/Button.tsx
+++ b/packages/design-system/components/Button/Button.tsx
@@ -1,10 +1,13 @@
-import { Box } from '../Box';
-import { button } from './Button.css';
-
 import { type ButtonHTMLAttributes, type ReactNode, forwardRef } from 'react';
+import type { Atoms } from '../../utils/atoms';
+import { Box } from '../Box';
+import * as styles from './Button.css';
 
-interface Props
-	extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'prefix'> {
+type OmitProps = 'prefix';
+
+interface ButtonProps
+	extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, OmitProps>,
+		Omit<Atoms, 'className' | 'color'> {
 	variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
 	size?: 'sm' | 'md' | 'lg';
 	rounded?: boolean;
@@ -12,13 +15,9 @@ interface Props
 	suffix?: ReactNode;
 }
 
-export const Button = forwardRef(
-	(
-		{ variant, size, rounded, prefix, suffix, children, ...restProps }: Props,
-		ref?: React.Ref<HTMLButtonElement>,
-	) => {
-		const buttonStyle = button({ variant, size, rounded });
-
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+	({ variant, size, rounded, prefix, suffix, children, ...restProps }, ref) => {
+		const buttonStyle = styles.button({ variant, size, rounded });
 		return (
 			<Box
 				as='button'

--- a/packages/design-system/components/Input/Input.tsx
+++ b/packages/design-system/components/Input/Input.tsx
@@ -1,23 +1,21 @@
-import { type InputHTMLAttributes, type Ref, forwardRef } from 'react';
-
 import { Box } from '../Box';
+
+import { type InputHTMLAttributes, forwardRef } from 'react';
+import type { Atoms } from '../../utils/atoms';
 import * as styles from './Input.css';
 
 type OmitProps = 'size' | 'width' | 'height';
 
-interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, OmitProps> {
+interface InputProps
+	extends Omit<InputHTMLAttributes<HTMLInputElement>, OmitProps>,
+		Omit<Atoms, 'className' | 'color'> {
 	variant?: 'primary' | 'outline' | 'ghost';
 	size?: 'sm' | 'md' | 'lg';
 	rounded?: boolean;
 }
-
-export const Input = forwardRef(
-	(
-		{ className, variant, size, rounded, ...restProps }: Props,
-		ref?: Ref<HTMLInputElement>,
-	) => {
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+	({ variant, size, rounded, ...restProps }, ref) => {
 		const inputStyle = styles.input({ variant, size, rounded });
-
 		return <Box as='input' className={inputStyle} ref={ref} {...restProps} />;
 	},
 );

--- a/packages/design-system/styles/reset.css.ts
+++ b/packages/design-system/styles/reset.css.ts
@@ -19,12 +19,6 @@ globalStyle('body', {
 // 	verticalAlign: 'baseline',
 // });
 
-// globalStyle('a', {
-// 	textDecoration: 'none',
-// 	outline: 'none',
-// 	color: 'none',
-// });
-
 globalStyle('*, *::before, *::after', {
 	margin: 0,
 	padding: 0,

--- a/packages/design-system/utils/atoms.ts
+++ b/packages/design-system/utils/atoms.ts
@@ -7,19 +7,50 @@ export interface Atoms extends Sprinkles {
 	className?: ClassValue;
 }
 
+/**
+ * Extracts Sprinkles props from the given props object.
+ * @param props - The props object.
+ * @returns An array containing the Sprinkles props and the remaining props.
+ *
+ * The `pick` function is used to extract the Sprinkles props from the `props` object.
+ * The `keys` variable contains an array of all the property keys defined in the `sprinkles` object.
+ * The `omit` function is used to extract the remaining props that are not Sprinkles props.
+ * The function returns an array with two elements: the Sprinkles props and the remaining props.
+ */
+
 const keys = Array.from(sprinkles.properties.keys());
 export const extractAtoms = <P extends object>(props: P) => [
 	pick(props, keys),
 	omit(props, keys),
 ];
 
-export function atoms(atoms: Atoms) {
+/**
+ * Generates a class name string based on the provided Atoms object.
+ * @param atoms - The Atoms object containing style properties.
+ * @returns The generated class name string.
+ *
+ * The function destructures the `atoms` object into `reset`, `className`, and the remaining `rest` properties.
+ * The `sprinkles` function is used to generate the class names for the `rest` properties.
+ * The `clsx` library is used to combine the generated `sprinklesClassNames`, the `className` property, and the `reset` class name (if provided).
+ * The final class name string is returned, which can be used to apply styles to a component.
+ */
+
+function generateClassNames(atoms: Atoms) {
 	const { reset, className, ...rest } = atoms;
 	const sprinklesClassNames = sprinkles(rest);
-
 	return clsx(
 		sprinklesClassNames,
 		className,
 		reset ? [elementResets[reset]] : null,
 	);
+}
+
+/**
+ * A utility function that generates a class name string based on the provided Atoms object.
+ * @param atoms - The Atoms object containing style properties.
+ * @returns The generated class name string.
+ */
+
+export function atoms(atoms: Atoms) {
+	return generateClassNames(atoms);
 }


### PR DESCRIPTION
## Motivation 🤔

- Integrate the Atoms utility in the Input and Button components to allow for more flexible styling using the sprinkles system.

<br>

## Key Changes 🔑

- Extended the InputProps and ButtonProps interfaces to include the Atoms type, which includes sprinkles props.
- Utilized the atoms utility function to generate the class names for the Input and Button components based on the provided Atoms object.

<br>

## To Reviews 🙏🏻

- Ensure the integration of Atoms and sprinkles props in the Input and Button components works as expected.
- Verify that the components can be styled using the sprinkles system without any issues.
- Review the updated documentation and ensure it provides clear explanations of the changes.
@ebokyung 
