### PR TITLE
Refactor: Add single type for handling Accordion component #20

### DIFF
--- a/apps/workshop/src/stories/Accordion/Accordion.stories.tsx
+++ b/apps/workshop/src/stories/Accordion/Accordion.stories.tsx
@@ -1,83 +1,76 @@
-import { Accordion } from '@jung/design-system';
+import { Accordion, type AccordionProps } from '@jung/design-system';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Accordion> = {
-  title: 'Components/Accordion',
-  component: Accordion,
-  tags: ['autodocs'],
-  parameters: {
-    layout: 'centered',
-  },
+	title: 'Components/Accordion',
+	component: Accordion,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'centered',
+	},
+	argTypes: {
+		type: {
+			options: ['single', 'multiple'],
+			control: { type: 'select' },
+		},
+	},
 } satisfies Meta<typeof Accordion>;
 
 export default meta;
 type Story = StoryObj<typeof Accordion>;
 
+const Template = (args: AccordionProps) => (
+	<Accordion type={args.type} style={{ width: '375px' }} {...args}>
+		<Accordion.Item>
+			<Accordion.Trigger top={<div>AccordionTrigger</div>}>
+				What is the Virtual DOM and how does it work in React?
+			</Accordion.Trigger>
+			<Accordion.Content>
+				<Accordion.Panel title='Answer'>
+					The Virtual DOM is a lightweight copy of the actual DOM used by React
+					to optimize the update process.
+				</Accordion.Panel>
+				<Accordion.Panel title='Answer2'>
+					By rendering a virtual representation of the UI, React can minimize
+					direct DOM manipulations and improve performance.
+				</Accordion.Panel>
+			</Accordion.Content>
+			<Accordion.Content>
+				<Accordion.Panel title='Follow-up Question 2'>
+					What are the benefits of using the Virtual DOM compared to direct DOM
+					manipulation?
+				</Accordion.Panel>
+			</Accordion.Content>
+		</Accordion.Item>
+		<Accordion.Item>
+			<Accordion.Trigger top={<div>Answered 2023.07.19 | Delete</div>}>
+				Can you explain the difference between `var`, `let`, and `const` in
+				JavaScript?
+			</Accordion.Trigger>
+			<Accordion.Content>
+				<Accordion.Panel>
+					`var` is function-scoped, while `let` and `const` are block-scoped.
+				</Accordion.Panel>
+			</Accordion.Content>
+		</Accordion.Item>
+		<Accordion.Item>
+			<Accordion.Trigger top={<div>Answered 2023.07.19 | Delete</div>}>
+				Can you explain the difference between `var`, `let`, and `const` in
+				JavaScript?
+			</Accordion.Trigger>
+			<Accordion.Content>
+				<Accordion.Panel>
+					`var` is function-scoped, while `let` and `const` are block-scoped.
+				</Accordion.Panel>
+			</Accordion.Content>
+		</Accordion.Item>
+	</Accordion>
+);
+
 export const Default: Story = {
-  render: (args) => (
-    <Accordion style={{ width: '375px' }} {...args}>
-      <Accordion.Item>
-        <Accordion.Trigger top={<div>Answered 2024.02.23 | Delete</div>}>
-          What is the Virtual DOM and how does it work in React?
-        </Accordion.Trigger>
-        <Accordion.Content>
-          <Accordion.Panel title="Answer">
-            The Virtual DOM is a lightweight copy of the actual DOM used by
-            React to optimize the update process. By rendering a virtual
-            representation of the UI, React can minimize direct DOM
-            manipulations and improve performance.
-          </Accordion.Panel>
-          <Accordion.Panel title="Follow-up Question 1">
-            How does React determine what to re-render in the DOM when state
-            changes?
-          </Accordion.Panel>
-          <Accordion.Panel title="Answer">
-            React uses a diffing algorithm, which compares the previous and the
-            new versions of the Virtual DOM to determine the minimal set of
-            changes necessary to update the actual DOM.
-          </Accordion.Panel>
-          <Accordion.Panel title="Follow-up Question 2">
-            What are the benefits of using the Virtual DOM compared to direct
-            DOM manipulation?
-          </Accordion.Panel>
-          <Accordion.Panel title="Answer">
-            Using the Virtual DOM reduces the cost of DOM updates, which can be
-            performance-intensive. It allows for efficient updates by batching
-            them and only touching the parts of the DOM that actually need to
-            change.
-          </Accordion.Panel>
-        </Accordion.Content>
-      </Accordion.Item>
-      <Accordion.Item>
-        <Accordion.Trigger top={<div>Answered 2023.07.19 | Delete</div>}>
-          Can you explain the difference between `var`, `let`, and `const` in
-          JavaScript?
-        </Accordion.Trigger>
-        <Accordion.Content>
-          <Accordion.Panel>
-            `var` is function-scoped, while `let` and `const` are block-scoped.
-            This scoping difference is crucial for managing variable visibility
-            and lifecycle in JavaScript applications.
-          </Accordion.Panel>
-          <Accordion.Panel title="Follow-up Question 1">
-            What issues might arise from using `var` in modern JavaScript?
-          </Accordion.Panel>
-          <Accordion.Panel title="Answer">
-            Using `var` can lead to common issues like variable hoisting and
-            unintended variable overriding, especially in loops or conditional
-            blocks, which can introduce bugs and make code maintenance harder.
-          </Accordion.Panel>
-          <Accordion.Panel title="Follow-up Question 2">
-            Why might you choose `const` over `let` when declaring a variable?
-          </Accordion.Panel>
-          <Accordion.Panel title="Answer">
-            Choosing `const` helps enforce immutability for the variable's
-            value, which can lead to safer, more predictable code. It's a best
-            practice when the variable's value should not change after initial
-            assignment.
-          </Accordion.Panel>
-        </Accordion.Content>
-      </Accordion.Item>
-    </Accordion>
-  ),
+	render: (args) => <Template {...args} type='single' />,
+};
+
+export const Multiple: Story = {
+	render: (args) => <Template {...args} type='multiple' />,
 };

--- a/packages/design-system/components/Accordion/Accordion.tsx
+++ b/packages/design-system/components/Accordion/Accordion.tsx
@@ -1,24 +1,76 @@
-import { type HTMLAttributes, forwardRef } from 'react';
+import {
+	Children,
+	type HTMLAttributes,
+	type ReactElement,
+	cloneElement,
+	forwardRef,
+	isValidElement,
+	useCallback,
+	useMemo,
+	useState,
+} from 'react';
 
 import type { OmitAtomProps } from '../../types/atoms';
 import { Box } from '../Box';
+import { AccordionContext } from './context/AccordionContext';
 
 export interface AccordionProps
 	extends HTMLAttributes<HTMLDivElement>,
-		OmitAtomProps {}
+		OmitAtomProps {
+	type?: 'single' | 'multiple';
+}
 
 export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
-	({ children, className, ...restProps }: AccordionProps, ref?) => {
+	(
+		{ type = 'single', children, className, ...restProps }: AccordionProps,
+		ref?,
+	) => {
+		const [openIndexes, setOpenIndexes] = useState<Set<number>>(new Set());
+
+		const handleToggleIndex = useCallback(
+			(index: number) => {
+				const newSet = new Set(openIndexes);
+				if (type === 'multiple') {
+					if (newSet.has(index)) {
+						newSet.delete(index);
+					} else {
+						newSet.add(index);
+					}
+				} else if (type === 'single') {
+					if (newSet.has(index)) {
+						newSet.delete(index);
+					} else {
+						newSet.clear();
+						newSet.add(index);
+					}
+				}
+
+				setOpenIndexes(newSet);
+			},
+			[openIndexes, type],
+		);
+
+		const value = useMemo(
+			() => ({ type, openIndexes, handleToggleIndex }),
+			[type, openIndexes, handleToggleIndex],
+		);
+
 		return (
-			<Box
-				ref={ref}
-				display='flex'
-				flexDirection='column'
-				rowGap='4'
-				{...restProps}
-			>
-				{children}
-			</Box>
+			<AccordionContext.Provider value={value}>
+				<Box
+					ref={ref}
+					display='flex'
+					flexDirection='column'
+					rowGap='4'
+					{...restProps}
+				>
+					{Children.map(children, (child, index) =>
+						isValidElement(child)
+							? cloneElement(child as ReactElement, { index: index + 1 })
+							: child,
+					)}
+				</Box>
+			</AccordionContext.Provider>
 		);
 	},
 );

--- a/packages/design-system/components/Accordion/AccordionContent.css.ts
+++ b/packages/design-system/components/Accordion/AccordionContent.css.ts
@@ -1,24 +1,41 @@
-import { createVar, globalStyle, style } from '@vanilla-extract/css';
+import { createVar, globalStyle, keyframes, style } from '@vanilla-extract/css';
 
+import { recipe } from '@vanilla-extract/recipes';
 import { sprinkles } from '../../styles';
 
 export const contentHeightVar = createVar();
 
-export const content = style([
-	sprinkles({
+export const accordionDown = keyframes({
+	from: { maxHeight: '0px' },
+	to: { maxHeight: contentHeightVar },
+});
+
+export const accordionUp = keyframes({
+	from: { maxHeight: contentHeightVar },
+	to: { maxHeight: '0px' },
+});
+
+export const content = recipe({
+	base: sprinkles({
 		display: 'flex',
 		flexDirection: 'column',
 		rowGap: '4',
 		overflow: 'hidden',
 	}),
-	{
-		maxHeight: contentHeightVar,
-		transitionProperty: 'max-height',
-		transitionDuration: '200ms',
-		transitionDelay: '100ms',
-		transitionTimingFunction: 'cubic-bezier(0.37, 0, 0.63, 1)',
+	variants: {
+		isOpen: {
+			true: {
+				animation: `${accordionDown} 0.3s cubic-bezier(0.37, 0, 0.63, 1)  forwards`,
+			},
+			false: {
+				animation: `${accordionUp} 0.3s cubic-bezier(0.37, 0, 0.63, 1) forwards`,
+			},
+		},
 	},
-]);
+	defaultVariants: {
+		isOpen: false,
+	},
+});
 
 export const contentChild = style([
 	sprinkles({

--- a/packages/design-system/components/Accordion/AccordionContent.tsx
+++ b/packages/design-system/components/Accordion/AccordionContent.tsx
@@ -8,6 +8,7 @@ import { useBeforeMatch } from '@jung/shared/hooks';
 import type { OmitAtomProps } from '../../types/atoms';
 import { Box } from '../Box';
 import { useAccordionContext } from './context/AccordionContext';
+import { useAccordionItemContext } from './context/AccordionItemContext';
 import { useExpandableHeight } from './hooks/useExpandableHeight';
 
 export interface AccordionContentProps
@@ -20,19 +21,26 @@ export const AccordionContent = forwardRef<
 	HTMLDivElement,
 	AccordionContentProps
 >(({ className, children, ...restProps }: AccordionContentProps, ref?) => {
-	const { toggle, handleToggle } = useAccordionContext();
+	const { openIndexes, handleToggleIndex } = useAccordionContext();
+	const { index, id } = useAccordionItemContext();
+	const isOpen = openIndexes.has(index!);
+
 	const contentRef = useRef<HTMLDivElement>(null);
-	useBeforeMatch<HTMLDivElement>(contentRef, handleToggle);
-	const contentHeight = useExpandableHeight<HTMLDivElement>(contentRef, toggle);
+	useBeforeMatch<HTMLDivElement>(contentRef, () => handleToggleIndex(index!));
+	const contentHeight = useExpandableHeight<HTMLDivElement>(contentRef, isOpen);
 
 	return (
 		<Box
-			ref={contentRef || ref}
 			style={assignInlineVars({
-				[S.contentHeightVar]: `${contentHeight + 1}px`,
+				[S.contentHeightVar]: `${contentHeight}px`,
 			})}
-			className={S.content}
-			HIDDEN={toggle ? undefined : 'until-found'}
+			className={S.content({ isOpen })}
+			ref={contentRef || ref}
+			HIDDEN={isOpen ? undefined : 'until-found'}
+			role='region'
+			aria-labelledby={id}
+			tabIndex={isOpen ? 0 : -1}
+			id={`${id}-content`}
 			{...restProps}
 		>
 			{Children.map(children, (child, index) => (

--- a/packages/design-system/components/Accordion/AccordionItem.tsx
+++ b/packages/design-system/components/Accordion/AccordionItem.tsx
@@ -1,30 +1,27 @@
 import * as S from './AccordionItem.css';
 
-import { type HTMLAttributes, forwardRef, useMemo } from 'react';
+import { type HTMLAttributes, forwardRef, useId } from 'react';
 
-import { useToggle } from '@jung/shared/hooks';
 import type { OmitAtomProps } from '../../types/atoms';
 import { Box } from '../Box';
-import { AccoridonContext } from './context/AccordionContext';
+import { AccordionItemContext } from './context/AccordionItemContext';
 
 export interface AccordionItemProps
 	extends HTMLAttributes<HTMLDivElement>,
-		OmitAtomProps {}
+		OmitAtomProps {
+	index?: number;
+}
 
 export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
-	({ children, ...restProps }: AccordionItemProps, ref?) => {
-		const { toggle, setToggle, handleToggle } = useToggle();
+	({ children, index, ...restProps }: AccordionItemProps, ref?) => {
+		const id = useId();
 
-		const value = useMemo(
-			() => ({ toggle, setToggle, handleToggle }),
-			[handleToggle, setToggle, toggle],
-		);
 		return (
-			<AccoridonContext.Provider value={value}>
+			<AccordionItemContext.Provider value={{ index, id }}>
 				<Box ref={ref} className={S.item} {...restProps}>
 					{children}
 				</Box>
-			</AccoridonContext.Provider>
+			</AccordionItemContext.Provider>
 		);
 	},
 );

--- a/packages/design-system/components/Accordion/AccordionPanel.tsx
+++ b/packages/design-system/components/Accordion/AccordionPanel.tsx
@@ -2,6 +2,7 @@ import { type HTMLAttributes, forwardRef, useRef } from 'react';
 
 import type { OmitAtomProps } from '../../types/atoms';
 import { Box } from '../Box';
+import { useAccordionItemContext } from './context/AccordionItemContext';
 
 export interface AccordionPanelProps
 	extends HTMLAttributes<HTMLDivElement>,
@@ -12,9 +13,17 @@ export interface AccordionPanelProps
 export const AccordionPanel = forwardRef<HTMLDivElement, AccordionPanelProps>(
 	({ children, title, ...restProps }: AccordionPanelProps, ref?) => {
 		const panelRef = useRef<HTMLDivElement>(null);
+		const { index, id } = useAccordionItemContext();
+		const panelId = `${id}-panel-${index}`;
 
 		return (
-			<Box ref={panelRef || ref} {...restProps}>
+			<Box
+				ref={panelRef || ref}
+				{...restProps}
+				role='region'
+				aria-labelledby={panelId}
+				aria-hidden={!restProps['aria-expanded']}
+			>
 				{title && (
 					// FIXME: 나중에 Typography 컴포넌트로 변경
 					<Box as='p' marginBottom='4' fontWeight='semibold'>

--- a/packages/design-system/components/Accordion/AccordionTrigger.tsx
+++ b/packages/design-system/components/Accordion/AccordionTrigger.tsx
@@ -6,6 +6,7 @@ import { ArrowDownOutlined, ArrowUpOutlined } from '../../assets/icons';
 import type { OmitAtomProps } from '../../types/atoms';
 import { Box } from '../Box';
 import { useAccordionContext } from './context/AccordionContext';
+import { useAccordionItemContext } from './context/AccordionItemContext';
 
 export interface AccordionTriggerProps
 	extends HTMLAttributes<HTMLDivElement>,
@@ -17,14 +18,19 @@ export const AccordionTrigger = forwardRef<
 	HTMLDivElement,
 	AccordionTriggerProps
 >(({ children, top, ...restProps }: AccordionTriggerProps, ref?) => {
-	const { toggle, handleToggle } = useAccordionContext();
+	const { openIndexes, handleToggleIndex } = useAccordionContext();
+	const { index, id } = useAccordionItemContext();
+	const isOpen = openIndexes.has(index!);
 
 	return (
 		<Box
 			ref={ref}
 			className={S.trigger}
-			onClick={handleToggle}
+			onClick={() => handleToggleIndex(index!)}
 			role='button'
+			id={id}
+			aria-expanded={isOpen}
+			aria-controls={id}
 			{...restProps}
 		>
 			<Box display='flex' flexDirection='column' rowGap='5'>
@@ -32,7 +38,7 @@ export const AccordionTrigger = forwardRef<
 				<Box as='p'>{children}</Box>
 			</Box>
 			<Box className={S.arrow}>
-				{toggle ? <ArrowUpOutlined /> : <ArrowDownOutlined />}
+				{isOpen ? <ArrowUpOutlined /> : <ArrowDownOutlined />}
 			</Box>
 		</Box>
 	);

--- a/packages/design-system/components/Accordion/context/AccordionContext.tsx
+++ b/packages/design-system/components/Accordion/context/AccordionContext.tsx
@@ -1,27 +1,18 @@
-import {
-	type Dispatch,
-	type SetStateAction,
-	createContext,
-	useContext,
-} from 'react';
+import { createContext, useContext } from 'react';
 
 type AccordionContextState = {
-	setToggle: Dispatch<SetStateAction<boolean>>;
-	toggle: boolean;
-	handleToggle: () => void;
+	type?: 'single' | 'multiple';
+	// setOpenIndexes: Dispatch<SetStateAction<Set<number>>>;
+	openIndexes: Set<number>;
+	handleToggleIndex: (index: number) => void;
 };
 
-const initialState = {
-	toggle: false,
-	setToggle: () => {},
-	handleToggle: () => {},
-};
-
-export const AccoridonContext =
-	createContext<AccordionContextState>(initialState);
+export const AccordionContext = createContext<AccordionContextState | null>(
+	null,
+);
 
 export const useAccordionContext = () => {
-	const context = useContext(AccoridonContext);
+	const context = useContext(AccordionContext);
 	if (!context) {
 		throw new Error('It should be rendered in the Accordion component');
 	}

--- a/packages/design-system/components/Accordion/context/AccordionItemContext.tsx
+++ b/packages/design-system/components/Accordion/context/AccordionItemContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+type AccordionItemContextState = {
+	index?: number;
+	id?: string;
+};
+
+export const AccordionItemContext =
+	createContext<AccordionItemContextState | null>(null);
+
+export const useAccordionItemContext = () => {
+	const context = useContext(AccordionItemContext);
+	if (!context) {
+		throw new Error('It should be rendered in the AccordionItem component');
+	}
+	return context;
+};

--- a/packages/design-system/components/Button/Button.css.ts
+++ b/packages/design-system/components/Button/Button.css.ts
@@ -15,7 +15,7 @@ export const button = recipe({
 				border: 'none',
 				background: {
 					base: 'primary',
-					hover: 'primary400',
+					hover: 'primary100',
 				},
 				color: 'white',
 			}),
@@ -23,7 +23,7 @@ export const button = recipe({
 				border: 'none',
 				background: {
 					base: 'secondary',
-					hover: 'secondary200',
+					hover: 'blue',
 				},
 				color: 'white',
 			}),

--- a/packages/design-system/components/index.ts
+++ b/packages/design-system/components/index.ts
@@ -1,3 +1,4 @@
+export type { AccordionProps } from './Accordion/Accordion';
 export { Accordion } from './Accordion';
 export { Tabs } from './Tabs';
 


### PR DESCRIPTION
## Motivation 🤔

- Implement handling for Accordion with multiple and single types.

<br>

## Key Changes 🔑

- Added support for single and multiple types in Accordion to allow one or multiple items to be open at the same time.
- Enhanced accessibility by adding appropriate aria attributes.

<br>

## To Reviews 🙏🏻
@KIMSEUNGGYU
[Storybook Documentation](https://663da8d85a1b09be59593dc2-mmadcqplpy.chromatic.com/?path=/docs/components-accordion--docs)
- Review the implementation of single and multiple types in Accordion.
- Verify the accessibility improvements with the added aria attributes.
